### PR TITLE
bugfix: dev server setup port at 3000

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,4 +20,7 @@ module.exports = {
     }),
     new ESLintPlugin({ extensions: ['js', 'jsx', 'ts', 'tsx'] }),
   ],
+  devServer: {
+    port: 3000,
+  },
 };


### PR DESCRIPTION
# What does this PR do?

dev point port at 3000

## Type of change

- [ ] Breaking Change
- [ ] Incremental Change
- [x] Implementation Only

## Changes

- webpack setup

## Feature Flags

## How to test (for reviewers)

1. Open project on browser on `localhost:3000`, it should work. 

## Demo

![image](https://github.com/PatriotWolf/react-webpack/assets/23714533/c5c16996-3f31-4374-bc00-674edaaf8cc2)
